### PR TITLE
Do not indent checkboxes

### DIFF
--- a/ipywidgets_jsonschema/__init__.py
+++ b/ipywidgets_jsonschema/__init__.py
@@ -1,3 +1,3 @@
 from ipywidgets_jsonschema.form import Form
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/ipywidgets_jsonschema/form.py
+++ b/ipywidgets_jsonschema/form.py
@@ -287,7 +287,7 @@ class Form:
             return self._construct_simple(schema, ipywidgets.IntText(), label=label)
 
     def _construct_boolean(self, schema, label=None, root=False):
-        return self._construct_simple(schema, ipywidgets.Checkbox(), label=label)
+        return self._construct_simple(schema, ipywidgets.Checkbox(indent=False), label=label)
 
     def _construct_null(self, schema, label=None, root=False):
         return self.construct_element()


### PR DESCRIPTION
This looks weird in our context, especially if the form is used in a horizontally limited column layout.

This fixes #9 