### PR TITLE
Remove tooltip from label: It is a no-op and deprecated

### DIFF
--- a/ipywidgets_jsonschema/form.py
+++ b/ipywidgets_jsonschema/form.py
@@ -364,7 +364,6 @@ class Form:
                 ipywidgets.Label(
                     title,
                     layout=ipywidgets.Layout(width="100%"),
-                    tooltip=tooltip,
                 ),
             )
 


### PR DESCRIPTION
This fixes #67 