### PR TITLE
Update GHA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ipywidgets-jsonschema - A widget generator for your Jupyter notebooks
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ssciwr/ipywidgets-jsonschema/CI)](https://github.com/ssciwr/ipywidgets-jsonschema/actions?query=workflow%3ACI)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ssciwr/ipywidgets-jsonschema/ci.yml?branch=main)](https://github.com/ssciwr/ipywidgets-jsonschema/actions/workflow/ci.yml)
 [![PyPI version](https://badge.fury.io/py/ipywidgets-jsonschema.svg)](https://badge.fury.io/py/ipywidgets-jsonschema)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ipywidgets-jsonschema.svg)](https://anaconda.org/conda-forge/ipywidgets-jsonschema)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ssciwr/ipywidgets-jsonschema/main?labpath=demo%2Fdemo.ipynb)


### PR DESCRIPTION
There has been a backwards-incompatible change to shields.io badges for Github Actions. They now identify workflows by their filename instead of their name field.