### PR TITLE
add method to update sub-schema in simple allOf case

### DIFF
--- a/ipywidgets_jsonschema/form.py
+++ b/ipywidgets_jsonschema/form.py
@@ -917,7 +917,9 @@ class Form:
         # If this is a trivial anyOf rule, we omit it:
         if len(schema[key]) == 1:
             if key == "allOf":
-                sub_schema = deep_update_missing({k:v for k,v in schema.items() if k != key}, schema[key][0])
+                sub_schema = deep_update_missing(
+                    {k: v for k, v in schema.items() if k != key}, schema[key][0]
+                )
             else:
                 sub_schema = schema[key][0]
             return self._construct(sub_schema, label=label, root=False)
@@ -979,7 +981,9 @@ def deep_update_missing(target, source):
     target = target.copy()
     for k, v in source.items():
         if k in target:
-            if isinstance(v, collections.abc.Mapping) and isinstance(target[k], collections.abc.Mapping):
+            if isinstance(v, collections.abc.Mapping) and isinstance(
+                target[k], collections.abc.Mapping
+            ):
                 target[k] = deep_update_missing(target[k], v)
         else:
             target[k] = v

--- a/tests/schemas/enum-allof.json
+++ b/tests/schemas/enum-allof.json
@@ -1,0 +1,23 @@
+{
+  "default": "A",
+  "schema": {
+    "default": "A",
+    "allOf": [
+      {
+        "title": "all of enum",
+        "description": "An enumeration.",
+        "enum": [
+          "A",
+          "B",
+          "C"
+        ],
+        "type": "string"
+      }
+    ]
+  },
+  "valid": [
+    "B",
+    "C"
+  ]
+}
+

--- a/tests/schemas/enum-allof.json
+++ b/tests/schemas/enum-allof.json
@@ -1,23 +1,22 @@
 {
   "default": "A",
   "schema": {
-    "default": "A",
     "allOf": [
       {
-        "title": "all of enum",
         "description": "An enumeration.",
         "enum": [
           "A",
           "B",
           "C"
         ],
+        "title": "all of enum",
         "type": "string"
       }
-    ]
+    ],
+    "default": "A"
   },
   "valid": [
     "B",
     "C"
   ]
 }
-

--- a/tests/test_update_missing.py
+++ b/tests/test_update_missing.py
@@ -1,0 +1,33 @@
+from ipywidgets_jsonschema.form import deep_update_missing
+
+
+def test_update_missing_insert():
+    target = {"A": 1}
+    source = {"B": 2}
+    result = deep_update_missing(target, source)
+    assert result["B"] == 2
+
+
+def test_update_missing_ignore():
+    target = {"A": 1}
+    source = {"A": 2}
+    result = deep_update_missing(target, source)
+    assert result["A"] == 1
+
+
+def test_update_missing_deep_insert():
+    target = {"A":
+        {
+            "B": {"E": 4},
+        }
+    }
+    source = {"A":
+        {
+            "B": {"E": 3, "F": 5},
+            "E": 4
+        }
+    }
+    result = deep_update_missing(target, source)
+    assert result["A"]["B"]["E"] == 4
+    assert result["A"]["B"]["F"] == 5
+    assert result["A"]["E"] == 4

--- a/tests/test_update_missing.py
+++ b/tests/test_update_missing.py
@@ -16,17 +16,12 @@ def test_update_missing_ignore():
 
 
 def test_update_missing_deep_insert():
-    target = {"A":
-        {
+    target = {
+        "A": {
             "B": {"E": 4},
         }
     }
-    source = {"A":
-        {
-            "B": {"E": 3, "F": 5},
-            "E": 4
-        }
-    }
+    source = {"A": {"B": {"E": 3, "F": 5}, "E": 4}}
     result = deep_update_missing(target, source)
     assert result["A"]["B"]["E"] == 4
     assert result["A"]["B"]["F"] == 5


### PR DESCRIPTION
This PR will try to merge the allOf sub-schema with the surround schema in a simple way. This addresses issues of otherwise missing properties like defaults. For example:
```json
  {
    "default": "A",
    "allOf": [
      {
        "title": "all of enum",
        "description": "An enumeration.",
        "enum": [
          "A",
          "B",
          "C"
        ],
        "type": "string"
      }
    ]
  }
```
this would not render a dropdown with a default selection of A.